### PR TITLE
fix non list connection opts handling

### DIFF
--- a/lib/wabbit/connection.ex
+++ b/lib/wabbit/connection.ex
@@ -97,17 +97,17 @@ defmodule Wabbit.Connection do
   end
 
   def init(opts) do
-    {current_opts, fallback_opts} =
+    {current_opts, fallback_opts, init_opts} =
       cond do
         Keyword.keyword?(opts) ->
-          {opts, []}
+          {opts, [], [opts]}
 
         is_binary(opts) ->
-          {opts, []}
+          {opts, [], [opts]}
 
         is_list(opts) && !Keyword.keyword?(opts) ->
           opts = Enum.shuffle(opts)
-          {hd(opts), tl(opts)}
+          {hd(opts), tl(opts), opts}
 
         true ->
           raise "Wabbit: unable to parse opts"
@@ -120,7 +120,7 @@ defmodule Wabbit.Connection do
       opts: current_opts,
       channels: %{},
       fallback_opts: fallback_opts,
-      init_opts: opts,
+      init_opts: init_opts,
       retry: 0
     }
 


### PR DESCRIPTION
This pull request fixes `init_opts` handling when the given options are not a list of configs or a list of URIs

We save the first given options to the connection so that we can recover the initial state in case of reconnection and not lose fallback. 

When we reconnect we want to remove the current connection from the `init_opts` and keep this as a fallback configuration list. This led to a bug because we were trying to `List.delete` on something that wasn't containing the right data.